### PR TITLE
Use the same font for line numbers

### DIFF
--- a/Themes/default/css/prismjs.css
+++ b/Themes/default/css/prismjs.css
@@ -1,4 +1,5 @@
 
+.block_code pre,
 .block_code pre code {
   font-family: "DejaVu Sans Mono", "Fira Code", Monaco, Consolas, monospace;
   white-space: pre-wrap;


### PR DESCRIPTION
Hi @dragomano, thank you very much for this mod,

I updated my forum to SMF 2.1.1 and my old geshi-based highlighter didn't work, so I switched to this one.
But I noticed that the line numbers didn't align correctly, e.g. in a code sample of 100 lines, the last 5-10 lines would appear after the 100 number.
I tracked it down to prismjs.css, which defines a different font for the code vs the line numbers, and I'm sending a patch to make them use the same font so that they align correctly.